### PR TITLE
Python examples are failing to execute

### DIFF
--- a/python/cp/build_matrices.py
+++ b/python/cp/build_matrices.py
@@ -8,6 +8,7 @@ from cp.cpOps import findGridInterpBasePt, buildInterpWeights
 def build_diff_matrix(int_band, dxvec, shape):
     """Builds a Laplacian matrix"""
     # TODO: generalize this!
+    shape = shape.astype(np.int64)
     dim = len(shape)
     if dim == 3:
         # Assume now that band is not a linear index, but a 3D index (ie, int_band)
@@ -64,6 +65,7 @@ def build_diff_matrix(int_band, dxvec, shape):
         return L[:, np.ravel_multi_index(int_band.T, shape)]
 
 def build_interp_matrix(int_band, cp, dx, p, ll, shape):
+    shape = shape.astype(np.int64)
     dim = len(shape)
     offsets = np.mgrid[tuple(
         slice(p+1) for _ in xrange(dim))].reshape((dim, -1))


### PR DESCRIPTION
### Issue:
The python examples do not run properly when I tried running them in iPython.

### iPython Output:
<img width="1024" alt="screen shot 2017-11-06 at 5 56 09 pm" src="https://user-images.githubusercontent.com/4994872/32430633-dd7737a6-c31b-11e7-8c22-8b2a56345373.png">

### Proposed Solution:
Cast the shape ndarray to integer values in order to be used as an index.
