### PR TITLE
Use E not Ebar in GS example

### DIFF
--- a/examples/general_boundary_conditions/GS_mobius.m
+++ b/examples/general_boundary_conditions/GS_mobius.m
@@ -104,6 +104,7 @@ for k = 1:length(band)
             n = -n ; 
         end 
 
+	% See Remark 2 of [WongMacdonaldLee2026]
         if norm([cpx_band(k)-cpbarx_band(k); cpy_band(k)-cpbary_band(k); cpz_band(k)-cpbarz_band(k)],2) >= 1e-4
             dvec(k) = 2*(w'*n) ;
         end

--- a/examples/general_boundary_conditions/GS_mobius.m
+++ b/examples/general_boundary_conditions/GS_mobius.m
@@ -1,4 +1,5 @@
-%% GS on mobius strip
+%% Gray--Scott on mobius strip
+% Forward Euler time-stepping
 
 clear ; close all ; % clc ;
 
@@ -115,8 +116,8 @@ Dmat = spdiags(dvec, 0, numpts, numpts) ;
 
 gamma = 2*dim*max(Du,Dv)/(dx^2);
 Imat = speye(size(Ebarqmat)) ;
-Au = Du*(Ebarqmat*Lmat) - gamma*(Imat - Ebarqmat - Dmat*(-kappa*Eqmat)) ;
-Av = Dv*(Ebarqmat*Lmat) - gamma*(Imat - Ebarqmat - Dmat*(-kappa*Eqmat)) ;
+Au = Du*(Eqmat*Lmat) - gamma*(Imat - Ebarqmat - Dmat*(-kappa*Eqmat)) ;
+Av = Dv*(Eqmat*Lmat) - gamma*(Imat - Ebarqmat - Dmat*(-kappa*Eqmat)) ;
 
 
 %% Record video
@@ -158,8 +159,8 @@ while t < Tf
   uvec0 = uvec ;
   vvec0 = vvec ;
 
-  uvec = uvec0 + dt*( Ebarqmat*f(uvec0,vvec0) + Au*uvec0 ) ;
-  vvec = vvec0 + dt*( Ebarqmat*g(uvec0,vvec0) + Av*vvec0 ) ;
+  uvec = uvec0 + dt*( Eqmat*f(uvec0,vvec0) + Au*uvec0 ) ;
+  vvec = vvec0 + dt*( Eqmat*g(uvec0,vvec0) + Av*vvec0 ) ;
   
 
   if ( (mod(kt,25)==0) || (kt<=10) || (kt==numtimesteps) )

--- a/examples/general_boundary_conditions/GS_mobius.m
+++ b/examples/general_boundary_conditions/GS_mobius.m
@@ -1,29 +1,11 @@
 %% GS on mobius strip
 
-clear ; close all ; % clc ; 
+clear ; close all ; % clc ;
 
 rng(1989)
 
-
-%% Construct a grid in the embedding space
-
-% grid size
-dx = 0.05 ;
-
-% make vectors of x, y, positions of the grid
-% x1d = (-1.8:dx:1.8)' ;
-% y1d = x1d ;
-% z1d = x1d ;
-
-% [xx, yy, zz] = meshgrid(x1d, y1d, z1d) ;
-
-% % Find closest points on the surface
-% R = 1 ; % radius of center circle
-% T = 0.35 ; % thickness
-% cpf = @cpMobiusStrip ; 
-% [cpbarx, cpbary, cpbarz, dist, bdy] = cpbar_3d(xx, yy, zz, cpf, R, T) ;
-% [cpx, cpy, cpz, ~, ~] = cpf(xx, yy, zz) ;
-
+dx = 0.05;
+% run make_mobius_grid to make this file
 load(['mobius_dx=', num2str(dx), '.mat']) ;
 
 

--- a/examples/general_boundary_conditions/make_mobius_grid.m
+++ b/examples/general_boundary_conditions/make_mobius_grid.m
@@ -1,0 +1,31 @@
+%% GS on mobius strip
+
+clear ; close all ; % clc ; 
+
+rng(1989)
+
+
+%% Construct a grid in the embedding space
+
+% grid size
+dx = 0.1 ;
+
+% make vectors of x, y, positions of the grid
+x1d = (-1.8:dx:1.8)' ;
+y1d = x1d ;
+z1d = x1d ;
+
+[xx, yy, zz] = meshgrid(x1d, y1d, z1d) ;
+
+% Find closest points on the surface
+R = 1 ; % radius of center circle
+T = 0.35 ; % thickness
+cpf = @cpMobiusStrip;
+[cpbarx, cpbary, cpbarz, dist, bdy] = cpbar_3d(xx, yy, zz, cpf, R, T) ;
+[cpx, cpy, cpz, ~, ~] = cpf(xx, yy, zz) ;
+
+
+save(['mobius_dx=', num2str(dx), '.mat'], ...
+     x1d, y1d, z1d, xx, yy, zz, cpx, cpy, cpz, cpbarx, cpbary, cpbarz, ...
+     dx, R, T);
+

--- a/examples/general_boundary_conditions/steklov_mobius.m
+++ b/examples/general_boundary_conditions/steklov_mobius.m
@@ -1,30 +1,9 @@
 %% Steklov problem on mobius strip
 
-clear ; close all ; % clc ; 
+clear ; close all ; % clc ;
 
-
-%% Construct a grid in the embedding space
-
-% % grid size
-% dx = 0.05 ;
-% 
-% % make vectors of x, y, positions of the grid
-% % x1d = (-1.8:dx:1.8)' ;
-% % y1d = x1d ;
-% % z1d = x1d ;
-% 
-% 
-% [xx, yy, zz] = meshgrid(x1d, y1d, z1d) ;
-% 
-% % Find closest points on the surface
-% R = 1 ; % radius of center circle
-% T = 0.35 ; % thickness
-% cpf = @cpMobiusStrip ; 
-% [cpbarx, cpbary, cpbarz, dist, bdy] = cpbar_3d(xx, yy, zz, cpf, R, T) ;
-% [cpx, cpy, cpz, ~, ~] = cpf(xx, yy, zz) ;
-
-dx = 0.025 ;
-
+dx = 0.05;
+% run make_mobius_grid to make this file
 load(['mobius_dx=', num2str(dx), '.mat']) ;
 
 


### PR DESCRIPTION
Use the E matrix, not Ebar in the GS.

I don't anticipate this makes any significant difference.